### PR TITLE
Restrict ConfigMap to single namespace plus security improvements

### DIFF
--- a/controllers/profile/profile.go
+++ b/controllers/profile/profile.go
@@ -42,14 +42,13 @@ const (
 
 	longWait = 1 * time.Minute
 
-	errGetProfile                = "cannot get profile"
-	errConfigMapNil              = "config map cannot be nil"
-	errConfigMapWithoutNamespace = "config map must have a namespace"
-	errConfigMapWithoutName      = "config map must have a name"
-	errSavingProfile             = "cannot save profile"
-	errCreatingOperatorDir       = "cannot create operator directory"
+	errGetProfile           = "cannot get profile"
+	errConfigMapNil         = "config map cannot be nil"
+	errConfigMapWithoutName = "config map must have a name"
+	errSavingProfile        = "cannot save profile"
+	errCreatingOperatorDir  = "cannot create operator directory"
 
-	seccompOperatorSuffix string      = "operator"
+	seccompOperatorSuffix string      = "seccomp/operator"
 	filePermissionMode    os.FileMode = 0o600
 
 	// MkdirAll won't create a directory if it does not have the execute bit.
@@ -58,7 +57,7 @@ const (
 )
 
 var (
-	kubeletSeccompRootPath string = "/var/lib/kubelet/seccomp"
+	kubeletSeccompRootPath string = "/var/lib/kubelet"
 )
 
 // SeccompProfileAnnotation is the annotation on a ConfigMap that specifies its
@@ -151,14 +150,12 @@ func getProfilePath(profileName string, cfg *corev1.ConfigMap) (string, error) {
 	if cfg.ObjectMeta.Name == "" {
 		return "", errors.New(errConfigMapWithoutName)
 	}
-	if cfg.ObjectMeta.Namespace == "" {
-		return "", errors.New(errConfigMapWithoutNamespace)
-	}
 
-	filePath := path.Join(kubeletSeccompRootPath,
-		filepath.Base(cfg.ObjectMeta.Namespace),
+	targetPath := dirTargetPath()
+	filePath := path.Join(targetPath,
 		filepath.Base(cfg.ObjectMeta.Name),
 		filepath.Base(profileName))
+
 	return filePath, nil
 }
 

--- a/controllers/profile/profile_test.go
+++ b/controllers/profile/profile_test.go
@@ -227,7 +227,7 @@ func TestGetProfilePath(t *testing.T) {
 		config      *corev1.ConfigMap
 	}{
 		"AppendNamespaceConfigNameAndProfile": {
-			want:        path.Join(kubeletSeccompRootPath, "config-namespace", "config-name", "file.js"),
+			want:        path.Join(kubeletSeccompRootPath, "seccomp/operator", "config-name", "file.js"),
 			profileName: "file.js",
 			config: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -237,7 +237,7 @@ func TestGetProfilePath(t *testing.T) {
 			},
 		},
 		"BlockTraversalAtProfileName": {
-			want:        path.Join(kubeletSeccompRootPath, "ns", "cfg", "file.js"),
+			want:        path.Join(kubeletSeccompRootPath, "seccomp/operator", "cfg", "file.js"),
 			profileName: "../../../../../file.js",
 			config: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -247,7 +247,7 @@ func TestGetProfilePath(t *testing.T) {
 			},
 		},
 		"BlockTraversalAtConfigName": {
-			want:        path.Join(kubeletSeccompRootPath, "ns", "cfg", "file.js"),
+			want:        path.Join(kubeletSeccompRootPath, "seccomp/operator", "cfg", "file.js"),
 			profileName: "file.js",
 			config: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -257,7 +257,7 @@ func TestGetProfilePath(t *testing.T) {
 			},
 		},
 		"BlockTraversalAtConfigNamespace": {
-			want:        path.Join(kubeletSeccompRootPath, "ns", "cfg", "file.js"),
+			want:        path.Join(kubeletSeccompRootPath, "seccomp/operator", "cfg", "file.js"),
 			profileName: "file.js",
 			config: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -271,14 +271,6 @@ func TestGetProfilePath(t *testing.T) {
 			config: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "config-namespace",
-				},
-			},
-		},
-		"ConfigMapWithoutNamespace": {
-			wantErr: errConfigMapWithoutNamespace,
-			config: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "config-name",
 				},
 			},
 		},

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -9,6 +9,30 @@ metadata:
   name: seccomp-operator
   namespace: security-operators
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: config-map-reader
+  namespace: security-operators
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: config-map-reader-binding
+  namespace: security-operators
+subjects:
+- kind: ServiceAccount
+  name: seccomp-operator
+  namespace: security-operators
+roleRef:
+  kind: Role
+  name: config-map-reader
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -28,11 +52,18 @@ spec:
         - name: seccomp-operator
           image: "securityoperators/seccomp-operator:latest"
           imagePullPolicy: Always
+          env:
+            - name: NAMESPACE_TO_WATCH
+              value: security-operators
           volumeMounts:
-          - mountPath: /var/lib/kubelet/seccomp
-            name: seccomp-root-path
+          - mountPath: /var/lib/kubelet
+            name: kubelet-root-path
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
       volumes:
-      - name: seccomp-root-path
+      - name: kubelet-root-path
         hostPath:
-          path: /var/lib/kubelet/seccomp
+          path: /var/lib/kubelet
           type: Directory

--- a/examples/profile.yaml
+++ b/examples/profile.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: default
+  namespace: security-operators
   name: test-profile
   annotations:
-    seccomp.security.alpha.kubernetes.io/profile: "true"
+    seccomp.security.kubernetes.io/profile: "true"
 data:
   profile-block.json: |-
     { "defaultAction": "SCMP_ACT_ERRNO", ... }

--- a/main.go
+++ b/main.go
@@ -26,6 +26,10 @@ import (
 	"github.com/saschagrunert/seccomp-operator/controllers/profile"
 )
 
+const (
+	namespaceToWatchDefault string = "security-operators"
+)
+
 var (
 	sync     = time.Second * 30
 	setupLog = ctrl.Log.WithName("setup")
@@ -34,14 +38,20 @@ var (
 func main() {
 	ctrl.SetLogger(klogr.New())
 
+	setupLog.Info("starting seccomp-operator")
 	cfg, err := ctrl.GetConfig()
 	if err != nil {
 		setupLog.Error(err, "cannot get config")
 		os.Exit(1)
 	}
 
+	namespaceToWatch := namespaceToWatchDefault
+	if os.Getenv("NAMESPACE_TO_WATCH") != "" {
+		namespaceToWatch = os.Getenv("NAMESPACE_TO_WATCH")
+	}
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		SyncPeriod: &sync,
+		Namespace:  namespaceToWatch,
 	})
 	if err != nil {
 		setupLog.Error(err, "cannot create manager")


### PR DESCRIPTION
- Add RBAC for service principal
- Add usage and fix example
- Drop caps and no_new_privs
- Restrict configmaps to a single namespace