### PR TITLE
Create yaml for non-root user and apply runtime/default seccomp.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,18 @@ FROM golang:1.14-alpine AS build
 WORKDIR /go/src/saschagrunert/seccomp-operator
 RUN apk --no-cache add build-base git gcc
 
+ENV USER=secuser
+ENV UID=2000
+# See https://stackoverflow.com/a/55757473/12429735RUN 
+RUN adduser \    
+    --disabled-password \    
+    --gecos "" \    
+    --home "/nonexistent" \    
+    --shell "/sbin/nologin" \    
+    --no-create-home \    
+    --uid "${UID}" \    
+    "${USER}"
+
 # Speed up build by leveraging docker layer caching
 COPY go.mod go.sum ./
 RUN go mod download
@@ -16,5 +28,9 @@ LABEL name="Seccomp Operator" \
       version="v0.0.1" \
       description="The Seccomp Operator makes it easier for cluster admins to manage their seccomp profiles and apply them to Kubernetes' workloads."
 
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build /etc/passwd /etc/passwd
+COPY --from=build /etc/group /etc/group
 COPY --from=build /seccomp-operator /
+
 ENTRYPOINT /seccomp-operator

--- a/controllers/profile/profile.go
+++ b/controllers/profile/profile.go
@@ -49,11 +49,11 @@ const (
 	errCreatingOperatorDir  = "cannot create operator directory"
 
 	seccompOperatorSuffix string      = "seccomp/operator"
-	filePermissionMode    os.FileMode = 0o600
+	filePermissionMode    os.FileMode = 0o644
 
 	// MkdirAll won't create a directory if it does not have the execute bit.
 	// https://github.com/golang/go/issues/22323#issuecomment-340568811
-	dirPermissionMode os.FileMode = 0o700
+	dirPermissionMode os.FileMode = 0o744
 )
 
 var (

--- a/deploy/operator-non-root.yaml
+++ b/deploy/operator-non-root.yaml
@@ -50,6 +50,28 @@ spec:
         name: seccomp-operator
     spec:
       serviceAccountName: seccomp-operator
+      initContainers:
+        - name: non-root-enabler
+          image: busybox 
+          # Creates folder /var/lib/kubelet/seccomp/operator and sets 2000:2000 as its owner.
+          # This is required to allow the main container to run as non-root.
+          command: ["/bin/sh", "-c"]
+          args:
+            - >
+              if [ ! -d "/var/lib/kubelet/seccomp/operator" ]; then 
+                /bin/mkdir -p /var/lib/kubelet/seccomp/operator && 
+                chmod 0744 /var/lib/kubelet/seccomp/operator && 
+                /bin/chown -R 2000:2000 /var/lib/kubelet/seccomp; 
+              fi
+          volumeMounts:
+          - mountPath: /var/lib/kubelet
+            name: kubelet-path
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+              add: ["CHOWN"]
       containers:
         - name: seccomp-operator
           image: securityoperators/seccomp-operator:latest
@@ -59,14 +81,16 @@ spec:
               value: seccomp-operator
           volumeMounts:
           - mountPath: /var/lib/kubelet
-            name: kubelet-root-path
+            name: kubelet-path
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            runAsUser: 2000
+            runAsGroup: 2000
             capabilities:
               drop: ["ALL"]
       volumes:
-      - name: kubelet-root-path
+      - name: kubelet-path
         hostPath:
           path: /var/lib/kubelet
           type: Directory

--- a/examples/pod.yaml
+++ b/examples/pod.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  annotations:
+    seccomp.security.alpha.kubernetes.io/pod: 'localhost/operator/test-profile/profile-allow.json'
+spec:
+  containers:
+  - name: test-container
+    image: nginx

--- a/examples/profile.yaml
+++ b/examples/profile.yaml
@@ -1,12 +1,14 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: security-operators
+  namespace: seccomp-operator
   name: test-profile
   annotations:
     seccomp.security.kubernetes.io/profile: "true"
 data:
   profile-block.json: |-
-    { "defaultAction": "SCMP_ACT_ERRNO", ... }
+    { "defaultAction": "SCMP_ACT_ERRNO" }
   profile-complain.json: |-
-    { "defaultAction": "SCMP_ACT_LOG", ... }
+    { "defaultAction": "SCMP_ACT_LOG" }
+  profile-allow.json: |-
+    { "defaultAction": "SCMP_ACT_ALLOW" }

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	namespaceToWatchDefault string = "security-operators"
+	namespaceToWatchDefault string = "seccomp-operator"
 )
 
 var (


### PR DESCRIPTION
- Adds an extra `.yaml` to deploy the seccomp-operator running the main container as non `root` user.
- Makes all containers to be bound by the default seccomp.


In the future, once we have profiled the operator, we may create its own tailor made seccomp which we would be able to apply to anything but the init-container.