### PR TITLE
Make kubelet seccomp root path const

### DIFF
--- a/internal/pkg/controllers/profile/profile.go
+++ b/internal/pkg/controllers/profile/profile.go
@@ -54,10 +54,8 @@ const (
 	// MkdirAll won't create a directory if it does not have the execute bit.
 	// https://github.com/golang/go/issues/22323#issuecomment-340568811
 	dirPermissionMode os.FileMode = 0o744
-)
 
-var (
-	kubeletSeccompRootPath string = "/var/lib/kubelet"
+	kubeletSeccompRootPath = "/var/lib/kubelet"
 )
 
 // SeccompProfileAnnotation is the annotation on a ConfigMap that specifies its

--- a/internal/pkg/controllers/profile/profile_test.go
+++ b/internal/pkg/controllers/profile/profile_test.go
@@ -134,13 +134,7 @@ func TestSaveProfileOnDisk(t *testing.T) {
 	if err != nil {
 		t.Error(errors.Wrap(err, "error creating temp file for tests"))
 	}
-	oldPath := kubeletSeccompRootPath
-	kubeletSeccompRootPath = dir
-
-	defer func() {
-		kubeletSeccompRootPath = oldPath
-		os.RemoveAll(dir)
-	}()
+	defer os.RemoveAll(dir)
 
 	cases := map[string]struct {
 		setup       func()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
We had it as a `var` because of the tests but we can use a const because
the tests do not rely on changing that global variable.
#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
cc @hasheddan @pjbgf 
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
